### PR TITLE
Add quick explorer css selectors

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -112,6 +112,18 @@ body.privacy-glasses.blur-ui .titlebar #quick-explorer:hover {
 	-webkit-text-fill-color: unset !important;
 }
 
+/* blur hover editor titlebar https://github.com/nothingislost/obsidian-hover-editor */
+
+body.privacy-glasses.blur-ui .hover-editor .popover-title {
+	text-shadow: 0 0 var(--blurLevel) currentColor !important;
+	-webkit-text-fill-color: transparent !important;
+}
+
+body.privacy-glasses.blur-ui .hover-editor .popover-title:hover {
+	text-shadow: none !important;
+	-webkit-text-fill-color: unset !important;
+}
+
 /*****************************************************************/
 /**  BLOCK CONTENT IN PREVIEW MODE								**/
 /*****************************************************************/

--- a/styles.css
+++ b/styles.css
@@ -100,6 +100,18 @@ body.privacy-glasses.blur-ui .workspace-drawer div:hover {
 	-webkit-text-fill-color: unset !important;
 }
 
+/* blur quick explorer https://github.com/pjeby/quick-explorer */
+
+body.privacy-glasses.blur-ui .titlebar #quick-explorer {
+	text-shadow: 0 0 var(--blurLevel) currentColor !important;
+	-webkit-text-fill-color: transparent !important;
+}
+
+body.privacy-glasses.blur-ui .titlebar #quick-explorer:hover {
+	text-shadow: none !important;
+	-webkit-text-fill-color: unset !important;
+}
+
 /*****************************************************************/
 /**  BLOCK CONTENT IN PREVIEW MODE								**/
 /*****************************************************************/


### PR DESCRIPTION
[Quick Explorer](https://github.com/pjeby/quick-explorer) is a really nice plugin, but I haven't been using it because it shows directory and file names unblurred.

Until I realized I could write one new CSS selector and have it blurred too. One more enabled plugin, one more pull request.