### PR TITLE
Fix: Avoid calling .then() on undefined value

### DIFF
--- a/main.js
+++ b/main.js
@@ -57,7 +57,7 @@ function hookViewStateChanged(view, onBeforeStateChange, onAfterStateChange) {
     function wrapper() {
         onBeforeStateChange(view);
         const r = original.apply(this, arguments);
-        if (typeof r.then === "function") {
+	    if (typeof r === "object" && typeof r.then === "function") {
             r.then(() => {
                 onAfterStateChange(view);
             });


### PR DESCRIPTION
It has error, when I use another plugin [float search](https://github.com/Quorafind/Obsidian-Float-Search). error message from console are as follows:

```console
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'then')
    at t.wrapper (plugin:privacy-glasses:60:22)
    at eval (plugin:float-search:6:28148)
```

I use chatGPT to debug and fix it, works for me. I thought maybe someone also have same issue, so I create this pr.